### PR TITLE
introduced new method get_as_bytes

### DIFF
--- a/luigi/contrib/s3.py
+++ b/luigi/contrib/s3.py
@@ -391,6 +391,9 @@ class S3Client(FileSystem):
     def get_as_bytes(self, s3_path):
         """
         Get the contents of an object stored in S3 as bytes
+
+        :param s3_path: URL for target S3 location
+        :return: File contents as pure bytes
         """
         (bucket, key) = self._path_to_bucket_and_key(s3_path)
         obj = self.s3.Object(bucket, key)
@@ -400,6 +403,10 @@ class S3Client(FileSystem):
     def get_as_string(self, s3_path, encoding='utf-8'):
         """
         Get the contents of an object stored in S3 as string.
+
+        :param s3_path: URL for target S3 location
+        :param encoding: Encoding to decode bytes to string
+        :return: File contents as a string
         """
         content = self.get_as_bytes(s3_path)
         return content.decode(encoding)

--- a/luigi/contrib/s3.py
+++ b/luigi/contrib/s3.py
@@ -398,6 +398,9 @@ class S3Client(FileSystem):
         return contents
 
     def get_as_string(self, s3_path, encoding='utf-8'):
+        """
+        Get the contents of an object stored in S3 as string.
+        """
         content = self.get_as_bytes(s3_path)
         return content.decode(encoding)
 

--- a/luigi/contrib/s3.py
+++ b/luigi/contrib/s3.py
@@ -388,16 +388,18 @@ class S3Client(FileSystem):
         # download the file
         self.s3.meta.client.download_file(bucket, key, destination_local_path)
 
-    def get_as_string(self, s3_path):
+    def get_as_bytes(self, s3_path):
         """
-        Get the contents of an object stored in S3 as a string.
+        Get the contents of an object stored in S3 as bytes
         """
         (bucket, key) = self._path_to_bucket_and_key(s3_path)
-
-        # get the content
         obj = self.s3.Object(bucket, key)
-        contents = obj.get()['Body'].read().decode('utf-8')
+        contents = obj.get()['Body'].read()
         return contents
+
+    def get_as_string(self, s3_path, encoding='utf-8'):
+        content = self.get_as_bytes(s3_path)
+        return content.decode(encoding)
 
     def isdir(self, path):
         """

--- a/test/contrib/s3_test.py
+++ b/test/contrib/s3_test.py
@@ -314,6 +314,15 @@ class TestS3Client(unittest.TestCase):
         self.assertEquals(content, self.tempFileContents.decode("utf-8"))
         tmp_file.close()
 
+    def test_get_as_bytes(self):
+        create_bucket()
+        s3_client = S3Client(AWS_ACCESS_KEY, AWS_SECRET_KEY)
+        s3_client.put(self.tempFilePath, 's3://mybucket/putMe')
+
+        contents = s3_client.get_as_bytes('s3://mybucket/putMe')
+
+        self.assertEquals(contents, self.tempFileContents)
+
     def test_get_as_string(self):
         create_bucket()
         s3_client = S3Client(AWS_ACCESS_KEY, AWS_SECRET_KEY)

--- a/test/contrib/s3_test.py
+++ b/test/contrib/s3_test.py
@@ -330,7 +330,16 @@ class TestS3Client(unittest.TestCase):
 
         contents = s3_client.get_as_string('s3://mybucket/putMe')
 
-        self.assertEquals(contents, self.tempFileContents.decode("utf-8"))
+        self.assertEquals(contents, self.tempFileContents.decode('utf-8'))
+
+    def test_get_as_string_latin1(self):
+        create_bucket()
+        s3_client = S3Client(AWS_ACCESS_KEY, AWS_SECRET_KEY)
+        s3_client.put(self.tempFilePath, 's3://mybucket/putMe')
+
+        contents = s3_client.get_as_string('s3://mybucket/putMe', encoding='ISO-8859-1')
+
+        self.assertEquals(contents, self.tempFileContents.decode('ISO-8859-1'))
 
     def test_get_key(self):
         create_bucket()

--- a/test/contrib/s3_test.py
+++ b/test/contrib/s3_test.py
@@ -326,18 +326,18 @@ class TestS3Client(unittest.TestCase):
     def test_get_as_string(self):
         create_bucket()
         s3_client = S3Client(AWS_ACCESS_KEY, AWS_SECRET_KEY)
-        s3_client.put(self.tempFilePath, 's3://mybucket/putMe')
+        s3_client.put(self.tempFilePath, 's3://mybucket/putMe2')
 
-        contents = s3_client.get_as_string('s3://mybucket/putMe')
+        contents = s3_client.get_as_string('s3://mybucket/putMe2')
 
         self.assertEquals(contents, self.tempFileContents.decode('utf-8'))
 
     def test_get_as_string_latin1(self):
         create_bucket()
         s3_client = S3Client(AWS_ACCESS_KEY, AWS_SECRET_KEY)
-        s3_client.put(self.tempFilePath, 's3://mybucket/putMe')
+        s3_client.put(self.tempFilePath, 's3://mybucket/putMe3')
 
-        contents = s3_client.get_as_string('s3://mybucket/putMe', encoding='ISO-8859-1')
+        contents = s3_client.get_as_string('s3://mybucket/putMe3', encoding='ISO-8859-1')
 
         self.assertEquals(contents, self.tempFileContents.decode('ISO-8859-1'))
 


### PR DESCRIPTION
## Description
Fixes hardcoded UTF-8 encoding inside `S3Client.get_as_string` method

## Motivation and Context
Issue: https://github.com/spotify/luigi/issues/2568

## Have you tested this? If so, how?
Yes. Tested running `tox`
